### PR TITLE
Fix circle map reference

### DIFF
--- a/src/components/Circle.js
+++ b/src/components/Circle.js
@@ -78,7 +78,7 @@ export default {
 
 	googleMapsReady () {
 		const options = this.$props
-		options.map = this.$map
+		options.map = this.$_map
 		this.$_circle = new window.google.maps.Circle(options)
 		this.bindProps(this.$_circle, boundProps)
 		this.redirectEvents(this.$_circle, redirectedEvents)


### PR DESCRIPTION
The `Marker` object is working but the `Circle` object is not. Base on [this line](https://github.com/Akryum/vue-googlemaps/blob/master/src/components/Marker.js#L98) it appears that `Marker` is using `$_map` while `Circle` is using `$map`. When I patched it locally it fixes the issue.